### PR TITLE
fix(promote_chat_member): add fallback empty string rank

### DIFF
--- a/pyrogram/methods/chats/promote_chat_member.py
+++ b/pyrogram/methods/chats/promote_chat_member.py
@@ -29,7 +29,7 @@ class PromoteChatMember:
             chat_id: Union[int, str],
             user_id: Union[int, str],
             privileges: "types.ChatPrivileges" = None,
-            title: Optional[str] = "",
+            title: Optional[str] = None,
     ) -> bool:
         """Promote or demote a user in a supergroup or a channel.
 
@@ -108,7 +108,7 @@ class PromoteChatMember:
                     delete_stories=privileges.can_delete_stories,
                     other=privileges.can_manage_chat
                 ),
-                rank=rank
+                rank=rank or ""
             )
         )
 


### PR DESCRIPTION
rank value error when called via `Chat.promote_member` which pass None rank as default.

<details><summary>Related Logs</summary>
<p>

```shell
Traceback (most recent call last):
  File "/home/mrmiss/test.py", line 159, in debug
    await chat.promote_member(user_id=user.id, privileges=bot.privileges)
  File "/home/mrmiss/python3.9/site-packages/pyrogram/types/user_and_chats/chat.py", line 997, in promote_member
    return await self._client.promote_chat_member(
  File "/home/mrmiss/python3.9/site-packages/pyrogram/methods/chats/promote_chat_member.py", line 90, in promote_chat_member
    await self.invoke(
  File "/home/mrmiss/python3.9/site-packages/pyrogram/methods/advanced/invoke.py", line 80, in invoke
    r = await self.session.invoke(
  File "/home/mrmiss/python3.9/site-packages/pyrogram/session/session.py", line 409, in invoke
    return await self.send(query, timeout=timeout)
  File "/home/mrmiss/python3.9/site-packages/pyrogram/session/session.py", line 327, in send
    message = self.msg_factory(data)
  File "/home/mrmiss/python3.9/site-packages/pyrogram/session/internals/msg_factory.py", line 38, in __call__
    len(body)
  File "/home/mrmiss/python3.9/site-packages/pyrogram/raw/core/tl_object.py", line 80, in __len__
    return len(self.write())
  File "/home/mrmiss/python3.9/site-packages/pyrogram/raw/functions/channels/edit_admin.py", line 95, in write
    b.write(String(self.rank))
  File "/home/mrmiss/python3.9/site-packages/pyrogram/raw/core/primitives/string.py", line 32, in __new__
    return super().__new__(cls, value.encode())
AttributeError: 'NoneType' object has no attribute 'encode'

``` 

</p>
</details> 