### PR TITLE
Catch `PeerIdInvalid` in `get_dialogs`

### DIFF
--- a/pyrogram/methods/chats/get_dialogs.py
+++ b/pyrogram/methods/chats/get_dialogs.py
@@ -21,7 +21,7 @@ from typing import AsyncGenerator, Optional
 
 import pyrogram
 from pyrogram import types, raw, utils
-from pyrogram.errors import ChannelPrivate
+from pyrogram.errors import ChannelPrivate, PeerIdInvalid
 
 
 class GetDialogs:
@@ -80,7 +80,7 @@ class GetDialogs:
                 chat_id = utils.get_peer_id(message.peer_id)
                 try:
                     messages[chat_id] = await types.Message._parse(self, message, users, chats)
-                except ChannelPrivate:
+                except (ChannelPrivate, PeerIdInvalid):
                     continue
 
             dialogs = []


### PR DESCRIPTION
This is undocumented in the Telegram Core API but does occur occasionally, causing get_dialogs to fail completely.
Not sure what this error corresponds to, but I chose to handle this the same way as ChannelPrivate - problematic dialogs are simply not assigned a `top_message` value.

I'd also consider eliminating the error type restriction in this line altogether