### PR TITLE
fix(send_media_group.py) Fixed media.caption_entities parameter not working 

### DIFF
--- a/pyrogram/methods/messages/send_media_group.py
+++ b/pyrogram/methods/messages/send_media_group.py
@@ -463,11 +463,15 @@ class SendMediaGroup:
             else:
                 raise ValueError(f"{i.__class__.__name__} is not a supported type for send_media_group")
 
+            message, entities = (
+                await utils.parse_text_entities(self, i.caption, i.parse_mode, i.caption_entities)).values()
+
             multi_media.append(
                 raw.types.InputSingleMedia(
                     media=media,
                     random_id=self.rnd_id(),
-                    **await self.parser.parse(i.caption, i.parse_mode)
+                    message=message,
+                    entities=entities,
                 )
             )
 

--- a/pyrogram/methods/messages/send_media_group.py
+++ b/pyrogram/methods/messages/send_media_group.py
@@ -463,15 +463,11 @@ class SendMediaGroup:
             else:
                 raise ValueError(f"{i.__class__.__name__} is not a supported type for send_media_group")
 
-            message, entities = (
-                await utils.parse_text_entities(self, i.caption, i.parse_mode, i.caption_entities)).values()
-
             multi_media.append(
                 raw.types.InputSingleMedia(
                     media=media,
                     random_id=self.rnd_id(),
-                    message=message,
-                    entities=entities,
+                    **(await utils.parse_text_entities(self, i.caption, i.parse_mode, i.caption_entities))
                 )
             )
 


### PR DESCRIPTION
hummm, yeah, as the title says, previous send_media_group didn't handle incoming media.caption_entities correctly. 

It means that all captions sent through send_media_group can only be formatted by pyrogram.parser.parse() method, and cannot be formatted by incoming entities.

Now Its fixed.