### PR TITLE
fix: properly handle FloodPremiumWait

### DIFF
--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -45,7 +45,8 @@ from pyrogram.errors import CDNFileHashMismatch
 from pyrogram.errors import (
     SessionPasswordNeeded,
     VolumeLocNotFound, ChannelPrivate,
-    BadRequest, ChannelInvalid, PersistentTimestampInvalid, PersistentTimestampOutdated
+    BadRequest, ChannelInvalid, PersistentTimestampInvalid, PersistentTimestampOutdated,
+    FloodWait, FloodPremiumWait
 )
 from pyrogram.handlers.handler import Handler
 from pyrogram.methods import Methods
@@ -1121,7 +1122,7 @@ class Client(Methods):
             if isinstance(e, asyncio.CancelledError):
                 raise e
 
-            if isinstance(e, pyrogram.errors.FloodWait):
+            if isinstance(e, (FloodWait, FloodPremiumWait)):
                 raise e
 
             return None
@@ -1346,7 +1347,7 @@ class Client(Methods):
                         await cdn_session.stop()
             except pyrogram.StopTransmission:
                 raise
-            except pyrogram.errors.FloodWait:
+            except (FloodWait, FloodPremiumWait):
                 raise
             except Exception as e:
                 log.exception(e)


### PR DESCRIPTION
closes #72

implementation yoinked from https://github.com/KurimuzonAkuma/pyrogram/commit/0d2bd648715b851f2506b5716f98e0d331234344   
now exports the FloodPremiumWait class when compiling the errors
