### PR TITLE
Update send_video.py retains video coven when video is file id

### DIFF
--- a/pyrogram/methods/messages/send_video.py
+++ b/pyrogram/methods/messages/send_video.py
@@ -335,6 +335,11 @@ class SendVideo:
                     )
                 else:
                     media = utils.get_input_media_from_file_id(video, FileType.VIDEO, ttl_seconds=(1 << 31) - 1 if view_once else ttl_seconds)
+                    if vidcover_file is not None:
+                        try:
+                            media.video_cover = vidcover_file
+                        except Exception as e:
+                            pass
                     media.spoiler = has_spoiler
             else:
                 thumb = await self.save_file(thumb)


### PR DESCRIPTION
Summary
This PR fixes a bug where passing a file_id for video together with a cover would not attach the cover to the sent media. Previously the code converted the cover to a helper/input object but did not attach it to the media returned by utils.get_input_media_from_file_id(video, FileType.VIDEO, ...). As a result, videos sent via file_id lost their video_cover.

Root cause

When video was a local file or URL we constructed raw.types.InputMediaUploadedDocument / InputMediaDocumentExternal and set video_cover correctly.

When video was a file_id, we used utils.get_input_media_from_file_id(...) to build media but never assigned media.video_cover = vidcover_file.

note: used ai to solve this dont know if its correct or not but worked and hope problem got detected.