### PR TITLE
fix AttributeError for MessageReplyStoryHeader missing user_id

### DIFF
--- a/pyrogram/utils.py
+++ b/pyrogram/utils.py
@@ -134,7 +134,10 @@ async def parse_messages(
             }
 
             message_reply_to_story = {
-                i.id: {'user_id': i.reply_to.user_id, 'story_id': i.reply_to.story_id}
+                i.id: {
+                    'user_id': getattr(i.reply_to, 'user_id', None), 
+                    'story_id': getattr(i.reply_to, 'story_id', None)
+                }
                 for i in messages.messages
                 if not isinstance(i, raw.types.MessageEmpty) and i.reply_to and isinstance(i.reply_to, raw.types.MessageReplyStoryHeader)
             }


### PR DESCRIPTION
if reply to story is in replies chain then client.get_messages(chat_id, reply_to_message_ids=reply_id, replies=-1) raises Exception.

File "...\Lib\site-packages\pyrogram\methods\messages\get_messages.py", line 119, in get_messages                                                                      messages = await utils.parse_messages(self, r, replies=replies)                                                                                                                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                   File "...\Lib\site-packages\pyrogram\utils.py", line 137, in parse_messages                                                                                            i.id: {'user_id': i.reply_to.user_id, 'story_id': i.reply_to.story_id}                                                                                                                                                ^^^^^^^^^^^^^^^^^^                                                                                                                                                            AttributeError: 'MessageReplyStoryHeader' object has no attribute 'user_id'