### PR TITLE
Add missing topic assignment in Message.__init__

### DIFF
--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -86,7 +86,7 @@ class Message(Object, Update):
 
         topic (:obj:`~pyrogram.types.ForumTopic`, *optional*):
             Topic the message belongs to.
-            only returned using when client.get_messages.
+            only returned when using client.get_messages.
 
         forward_origin (:obj:`~pyrogram.types.MessageOrigin`, *optional*):
             Information about the original message for forwarded messages.
@@ -573,6 +573,7 @@ class Message(Object, Update):
         self.sender_business_bot = sender_business_bot
         self.date = date
         self.chat = chat
+        self.topic = topic
         self.forward_origin = forward_origin
         self.external_reply = external_reply
         self.is_topic_message = is_topic_message


### PR DESCRIPTION
It is confusing that `Message.__init__` has the `topic` arg but never uses it.

This line was removed in this commit https://github.com/Mayuri-Chan/pyrofork/commit/389a13588319b752dea72607dbfe4b8e9db7f4a4 . Was there any reason of this change?

https://github.com/Mayuri-Chan/pyrofork/blob/6b28d305c0b29ca94d1127691f9bb82a949e77f5/pyrogram/types/messages_and_media/message.py#L549