### PR TITLE
MTProto Update: gifted_premium.py argument mismatch

### DIFF
--- a/pyrogram/session/session.py
+++ b/pyrogram/session/session.py
@@ -415,29 +415,29 @@ class Session:
 
         query_name = ".".join(inner_query.QUALNAME.split(".")[1:])
 
-        while True:
-            try:
-                return await self.send(query, timeout=timeout)
-            except (FloodWait, FloodPremiumWait) as e:
-                amount = e.value
+        try:
+            return await self.send(query, timeout=timeout)
+        except (FloodWait, FloodPremiumWait) as e:
+            amount = e.value
 
-                if amount > sleep_threshold >= 0:
-                    raise
+            if amount > sleep_threshold >= 0:
+                raise
+            if retries <= 0:
+                raise
+            amount += 1+max(0,self.MAX_RETRIES-retries)
 
-                log.warning('[%s] Waiting for %s seconds before continuing (required by "%s")',
-                            self.client.name, amount, query_name)
+            log.warning(f"[{self.client.name}] Waiting for {amount} seconds before continuing (required by \"{query_name}\"): {retries} left of {self.MAX_RETRIES}")
+            await asyncio.sleep(amount)
+        except (OSError, InternalServerError, ServiceUnavailable) as e:
+            if retries <= 0:
+                raise e from None
 
-                await asyncio.sleep(amount)
-            except (OSError, InternalServerError, ServiceUnavailable) as e:
-                if retries == 0:
-                    raise e from None
+            (log.warning if retries < 2 else log.info)(
+                '[%s] Retrying "%s" due to: %s',
+                Session.MAX_RETRIES - retries + 1,
+                query_name, str(e) or repr(e)
+            )
 
-                (log.warning if retries < 2 else log.info)(
-                    '[%s] Retrying "%s" due to: %s',
-                    Session.MAX_RETRIES - retries + 1,
-                    query_name, str(e) or repr(e)
-                )
+            await asyncio.sleep(0.5)
 
-                await asyncio.sleep(0.5)
-
-                return await self.invoke(query, retries - 1, timeout)
+        return await self.invoke(query, retries=retries - 1, timeout=timeout, sleep_threshold=sleep_threshold)

--- a/pyrogram/types/object.py
+++ b/pyrogram/types/object.py
@@ -17,15 +17,51 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrofork.  If not, see <http://www.gnu.org/licenses/>.
 
+import inspect
+import logging
+import traceback
 import typing
+import os
 from datetime import datetime
 from enum import Enum
 from json import dumps
 
 import pyrogram
 
+PYROGRAM_UNSAFE_PARSE = os.environ.get("PYROGRAM_UNSAFE_PARSE", "0") == "1"
 
-class Object:
+class ObjectMeta(type):
+    def __init__(cls, name, bases, namespace):
+        super().__init__(name, bases, namespace)
+        if ('_parse' in namespace) and not PYROGRAM_UNSAFE_PARSE:
+            original = namespace['_parse']
+            original_func = original.__func__ if isinstance(original, staticmethod) else original
+
+            def _make_safe(func, klass):
+                if inspect.iscoroutinefunction(func):
+                    async def _parse(*args, **kwargs):
+                        try:
+                            return await func(*args, **kwargs)
+                        except Exception:
+                            logging.error(
+                                f"Error parsing {klass.__name__}:\n" + traceback.format_exc()
+                            )
+                            return None
+                else:
+                    def _parse(*args, **kwargs):
+                        try:
+                            return func(*args, **kwargs)
+                        except Exception:
+                            logging.error(
+                                f"Error parsing {klass.__name__}:\n" + traceback.format_exc()
+                            )
+                            return None
+                return staticmethod(_parse)
+
+            cls._parse = _make_safe(original_func, cls)
+
+
+class Object(metaclass=ObjectMeta):
     def __init__(self, client: "pyrogram.Client" = None):
         self._client = client
 

--- a/pyrogram/types/payments/gifted_premium.py
+++ b/pyrogram/types/payments/gifted_premium.py
@@ -41,7 +41,10 @@ class GiftedPremium(Object):
             The paid amount, in the smallest units of the cryptocurrency; 0 if none
 
         month_count (``int``):
-            Number of months the Telegram Premium subscription will be active
+            Number of months the Telegram Premium subscription will be active (int(days/30))
+
+        day_count (``int``):
+            Number of days the Telegram Premium subscription will be active
     """
 
     def __init__(
@@ -52,7 +55,8 @@ class GiftedPremium(Object):
         amount: int = None,
         cryptocurrency: str = None,
         cryptocurrency_amount: int = None,
-        month_count: int = None
+        month_count: int = None,
+        day_count: int = None
     ):
         super().__init__()
 
@@ -62,6 +66,7 @@ class GiftedPremium(Object):
         self.cryptocurrency = cryptocurrency
         self.cryptocurrency_amount = cryptocurrency_amount
         self.month_count = month_count
+        self.day_count = day_count
 
     @staticmethod
     async def _parse(
@@ -75,5 +80,6 @@ class GiftedPremium(Object):
             amount=gifted_premium.amount,
             cryptocurrency=getattr(gifted_premium, "crypto_currency", None),
             cryptocurrency_amount=getattr(gifted_premium, "crypto_amount", None),
-            month_count=gifted_premium.months
+            month_count=int(gifted_premium.days / 30),
+            day_count=gifted_premium.days
         )


### PR DESCRIPTION
The generated `raw.types.message_action_gift_premium` (only visible after compilation) contains:
```
        currency (``str``):
            N/A

        amount (``int`` ``64-bit``):
            N/A

        days (``int`` ``32-bit``):
            N/A

        crypto_currency (``str``, *optional*):
            N/A

        crypto_amount (``int`` ``64-bit``, *optional*):
            N/A

        message (:obj:`TextWithEntities <pyrogram.raw.base.TextWithEntities>`, *optional*):
            N/A
```
As you'll notice it currently uses `days` not `months`
Kept `month_count` in case anyone is using it