### PR TITLE
Correct AsyncGenerator typing annotations

### DIFF
--- a/pyrogram/methods/chats/get_chat_event_log.py
+++ b/pyrogram/methods/chats/get_chat_event_log.py
@@ -33,7 +33,7 @@ class GetChatEventLog:
         limit: int = 0,
         filters: "types.ChatEventFilter" = None,
         user_ids: List[Union[int, str]] = None
-    ) -> Optional[AsyncGenerator["types.ChatEvent", None]]:
+    ) -> AsyncGenerator["types.ChatEvent"]:
         """Get the actions taken by chat members and administrators in the last 48h.
 
         Only available for supergroups and channels. Requires administrator rights.

--- a/pyrogram/methods/chats/get_chat_members.py
+++ b/pyrogram/methods/chats/get_chat_members.py
@@ -65,7 +65,7 @@ class GetChatMembers:
         query: str = "",
         limit: int = 0,
         filter: "enums.ChatMembersFilter" = enums.ChatMembersFilter.SEARCH
-    ) -> Optional[AsyncGenerator["types.ChatMember", None]]:
+    ) -> AsyncGenerator["types.ChatMember"]:
         """Get the members list of a chat.
 
         A chat can be either a basic group, a supergroup or a channel.

--- a/pyrogram/methods/chats/get_dialogs.py
+++ b/pyrogram/methods/chats/get_dialogs.py
@@ -28,7 +28,7 @@ class GetDialogs:
     async def get_dialogs(
         self: "pyrogram.Client",
         limit: int = 0
-    ) -> Optional[AsyncGenerator["types.Dialog", None]]:
+    ) -> AsyncGenerator["types.Dialog"]:
         """Get a user's dialogs sequentially.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/forums/get_forum_topics.py
+++ b/pyrogram/methods/forums/get_forum_topics.py
@@ -55,7 +55,7 @@ class GetForumTopics:
         self: "pyrogram.Client",
         chat_id: Union[int, str],
         limit: int = 0
-    ) -> Optional[AsyncGenerator["types.ForumTopic", None]]:
+    ) -> AsyncGenerator["types.ForumTopic"]:
         """Get forum topics from a chat.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/forums/get_forum_topics_count.py
+++ b/pyrogram/methods/forums/get_forum_topics_count.py
@@ -31,7 +31,7 @@ class GetForumTopicsCount:
     async def get_forum_topics_count(
         self: "pyrogram.Client",
         chat_id: Union[int, str]
-    ) -> Optional[AsyncGenerator["types.ForumTopic", None]]:
+    ) -> int:
         """Get forum topics count from a chat.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/invite_links/get_chat_admin_invite_links.py
+++ b/pyrogram/methods/invite_links/get_chat_admin_invite_links.py
@@ -31,7 +31,7 @@ class GetChatAdminInviteLinks:
         admin_id: Union[int, str],
         revoked: bool = False,
         limit: int = 0,
-    ) -> Optional[AsyncGenerator["types.ChatInviteLink", None]]:
+    ) -> AsyncGenerator["types.ChatInviteLink"]:
         """Get the invite links created by an administrator in a chat.
 
         .. note::

--- a/pyrogram/methods/invite_links/get_chat_invite_link_joiners.py
+++ b/pyrogram/methods/invite_links/get_chat_invite_link_joiners.py
@@ -30,7 +30,7 @@ class GetChatInviteLinkJoiners:
         chat_id: Union[int, str],
         invite_link: str,
         limit: int = 0
-    ) -> Optional[AsyncGenerator["types.ChatJoiner", None]]:
+    ) -> AsyncGenerator["types.ChatJoiner"]:
         """Get the members who joined the chat with the invite link.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/invite_links/get_chat_join_requests.py
+++ b/pyrogram/methods/invite_links/get_chat_join_requests.py
@@ -30,7 +30,7 @@ class GetChatJoinRequests:
         chat_id: Union[int, str],
         limit: int = 0,
         query: str = ""
-    ) -> Optional[AsyncGenerator["types.ChatJoiner", None]]:
+    ) -> AsyncGenerator["types.ChatJoiner"]:
         """Get the pending join requests of a chat.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/messages/get_chat_history.py
+++ b/pyrogram/methods/messages/get_chat_history.py
@@ -66,7 +66,7 @@ class GetChatHistory:
         min_id: int = 0,
         max_id: int = 0,
         reverse: Optional[bool] = None
-    ) -> Optional[AsyncGenerator["types.Message", None]]:
+    ) -> AsyncGenerator["types.Message"]
         """Get messages from a chat history.
 
         The messages are returned in reverse chronological order.

--- a/pyrogram/methods/messages/get_discussion_replies.py
+++ b/pyrogram/methods/messages/get_discussion_replies.py
@@ -29,7 +29,7 @@ class GetDiscussionReplies:
         chat_id: Union[int, str],
         message_id: int,
         limit: int = 0,
-    ) -> Optional[AsyncGenerator["types.Message", None]]:
+    ) -> AsyncGenerator["types.Message"]
         """Get the message replies of a discussion thread.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/messages/search_global.py
+++ b/pyrogram/methods/messages/search_global.py
@@ -34,7 +34,7 @@ class SearchGlobal:
         groups_only: Optional[bool] = None,
         users_only: Optional[bool] = None,
         limit: int = 0,
-    ) -> Optional[AsyncGenerator["types.Message", None]]:
+    ) -> AsyncGenerator["types.Message"]:
         """Search messages globally from all of your chats.
 
         If you want to get the messages count only, see :meth:`~pyrogram.Client.search_global_count`.

--- a/pyrogram/methods/messages/search_messages.py
+++ b/pyrogram/methods/messages/search_messages.py
@@ -71,7 +71,7 @@ class SearchMessages:
         limit: int = 0,
         from_user: Union[int, str] = None,
         thread_id: int = None
-    ) -> Optional[AsyncGenerator["types.Message", None]]:
+    ) -> AsyncGenerator["types.Message"]
         """Search for text and media messages inside a specific chat.
 
         If you want to get the messages count only, see :meth:`~pyrogram.Client.search_messages_count`.

--- a/pyrogram/methods/users/get_all_stories.py
+++ b/pyrogram/methods/users/get_all_stories.py
@@ -28,7 +28,7 @@ log = logging.getLogger(__name__)
 class GetAllStories:
     async def get_all_stories(
         self: "pyrogram.Client"
-    ) -> Optional[AsyncGenerator["types.Story", None]]:
+    ) -> AsyncGenerator["types.Story"]:
         """Get all active stories.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/users/get_peer_stories.py
+++ b/pyrogram/methods/users/get_peer_stories.py
@@ -29,7 +29,7 @@ class GetPeerStories:
     async def get_peer_stories(
         self: "pyrogram.Client",
         chat_id: Union[int, str]
-    ) -> Optional[AsyncGenerator["types.Story", None]]:
+    ) -> AsyncGenerator["types.Story"]
         """Get all active stories from an user/channel by using user identifiers.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/users/get_stories_history.py
+++ b/pyrogram/methods/users/get_stories_history.py
@@ -31,7 +31,7 @@ class GetUserStoriesHistory:
         chat_id: int = None,
         limit: int = 0,
         offset_id: int = 0
-    ) -> Optional[AsyncGenerator["types.Story", None]]:
+    ) -> AsyncGenerator["types.Story"]:
         """Get stories history.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/types/user_and_chats/chat.py
+++ b/pyrogram/types/user_and_chats/chat.py
@@ -1195,7 +1195,7 @@ class Chat(Object):
         query: str = "",
         limit: int = 0,
         filter: "enums.ChatMembersFilter" = enums.ChatMembersFilter.SEARCH
-    ) -> Optional[AsyncGenerator["types.ChatMember", None]]:
+    ) -> AsyncGenerator["types.ChatMember"]:
         """Bound method *get_members* of :obj:`~pyrogram.types.Chat`.
 
         Use as a shortcut for:


### PR DESCRIPTION
When using pyrofork from VSCode and a more recent Python target all the methods returning an AsyncGenerator are identified as potentially returning None since they are marked with Optional.

I'm not sure if this change creates a problem for earlier Python versions.