### PR TITLE
fix: resolve NameError in export_folder_link, secure RNG, and update deprecated mongo method

### DIFF
--- a/pyrogram/crypto/prime.py
+++ b/pyrogram/crypto/prime.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrofork.  If not, see <http://www.gnu.org/licenses/>.
 
-from random import randint
+import secrets
 
 CURRENT_DH_PRIME = int(
     "C71CAEB9C6B1C9048E6C522F70F13F73980D40238E3E21C14934D037563D930F"
@@ -48,7 +48,7 @@ def decompose(pq: int) -> int:
     if pq % 2 == 0:
         return 2
 
-    y, c, m = randint(1, pq - 1), randint(1, pq - 1), randint(1, pq - 1)
+    y, c, m = secrets.randbelow(pq - 1) + 1, secrets.randbelow(pq - 1) + 1, secrets.randbelow(pq - 1) + 1
     g = r = q = 1
     x = ys = 0
 

--- a/pyrogram/methods/chats/export_folder_link.py
+++ b/pyrogram/methods/chats/export_folder_link.py
@@ -18,7 +18,7 @@
 #  along with Pyrofork.  If not, see <http://www.gnu.org/licenses/>.
 
 import pyrogram
-from pyrogram import raw
+from pyrogram import raw, types
 
 
 class ExportFolderLink:
@@ -54,10 +54,10 @@ class ExportFolderLink:
             peers.extend(iter(folder.included_chats))
 
         if folder.excluded_chats:
-            peers.extend(iter(folder.included_chats))
+            peers.extend(iter(folder.excluded_chats))
 
         if folder.pinned_chats:
-            peers.extend(iter(folder.included_chats))
+            peers.extend(iter(folder.pinned_chats))
 
         r = await self.invoke(
             raw.functions.chatlists.ExportChatlistInvite(

--- a/pyrogram/storage/mongo_storage.py
+++ b/pyrogram/storage/mongo_storage.py
@@ -116,7 +116,7 @@ class MongoStorage(Storage):
         try:
             await self._session.delete_one({'_id': 0})
             if self._remove_peers:
-                await self._peer.remove({})
+                await self._peer.delete_many({})
         except Exception as _:
             return
 


### PR DESCRIPTION
## Overview
This Pull Request addresses several bugs and deprecations discovered during a static analysis of the codebase.

## Fixes Included

1. **`NameError` & Logic Bug in `export_folder_link.py`**
   - **Crash Fix:** Added the missing `types` import to prevent a `NameError` crash when `types.ExportedFolderLink._parse(r)` is called.
   - **Logic Fix:** Fixed a copy-paste error where `folder.included_chats` was mistakenly appended to the `peers` list for both `excluded_chats` and `pinned_chats` conditions.

2. **Deprecation in `mongo_storage.py`**
   - **Fix:** Replaced the deprecated `remove({})` method with `delete_many({})`. `remove()` was removed in PyMongo v4.0+, causing silent failures within the try-except block when `remove_peers=True` is used.

3. **Insecure RNG in `prime.py`**
   - **Security Fix:** Replaced `random.randint` with the cryptographically secure `secrets.randbelow` for prime generation.
